### PR TITLE
Fix broken License Link on Downloads Page

### DIFF
--- a/download.md
+++ b/download.md
@@ -8,7 +8,7 @@ class: download
 
 # Riot v**{{ site.version }}**
 
-View our [version history](/release-notes). All Files are Open Source with [MIT License](/license/).
+View our [version history](/release-notes). All Files are Open Source with [MIT License](/LICENSE/).
 
 ## Direct downloads
 


### PR DESCRIPTION
At least in Chrome, it seems that it cannot find the LICENSE page if the letters are lower case. Writing the link in upper case fixes the broken link.